### PR TITLE
fix: example awscliapppod

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,16 +120,26 @@ spec:
       secretName: bucketcreds
 ```
 An example awscli pod can be found at `project/examples/awscliapppod.yaml`
-
+This Pod will list the buckets and then writes a test file to the new bucket.
 ```
 $ kubectl create -f project/examples/awscliapppod.yaml
-$ kubectl exec -it awscli bash
-root@awscli:/aws# sh test.sh
+$ kubectl logs awscli
+Defaulted container "awscli" out of: awscli, write-aws-credentials (init), write-test-file (init)
++ aws s3 ls
+2024-12-20 19:38:40 sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
+++ cat /tmp/test-directory/file.txt
++ readonly BUCKET_NAME=sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
++ BUCKET_NAME=sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
+++ date +%Y%m%d_%H%M%S
++ readonly FILE_NAME=20241220_213034.txt
++ FILE_NAME=20241220_213034.txt
++ aws s3 cp /tmp/test-directory/file.txt s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt
+upload: ../tmp/test-directory/file.txt to s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt
++ aws s3 cp s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt -
+sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
 ```
-`test.sh` is a sample test script in awscli pod which will do a list-buckets and put-object operation using credentials of newly created user.
 
-Credentials are available at `/data/cosi/credentials`
-in the awscli pod
+Credentials are available at `/data/cosi/BucketInfo` in the awscli Pod.
 
 ### Deletion of newly created user
 ```

--- a/README.md
+++ b/README.md
@@ -142,13 +142,15 @@ sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
 Credentials are available at `/data/cosi/BucketInfo` in the awscli Pod.
 
 ### Deletion of newly created user
-```
+```sh
 $ kubectl delete bucketaccess sample-bucketaccess
+$ kubectl delete bucketaccessclass sample-bucketaccessclass
 ```
 
 ### Deletion of newly created bucket
-```
+```sh
 $ kubectl delete bucketclaim sample-bucketclaim
+$ kubectl delete bucketclass sample-bucketclass
 ```
 
 ## Updating the Nutanix Object Store config

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ spec:
 ```
 An example awscli pod can be found at `project/examples/awscliapppod.yaml`
 This Pod will list the buckets and then writes a test file to the new bucket.
-```
+```sh
 $ kubectl create -f project/examples/awscliapppod.yaml
 $ kubectl logs awscli
 Defaulted container "awscli" out of: awscli, write-aws-credentials (init), write-test-file (init)

--- a/project/examples/awscliapppod.yaml
+++ b/project/examples/awscliapppod.yaml
@@ -3,16 +3,88 @@ kind: Pod
 metadata:
   name: awscli
 spec:
+  restartPolicy: OnFailure
+  initContainers:
+    - name: write-aws-credentials
+      image: ghcr.io/itchyny/gojq:0.12.17
+      command:
+        - "sh"
+        - "-o"
+        - "xtrace" # Verbose output
+        - "-o"
+        - "errexit" # Exit on any error, except in a pipeline
+        - "-c"
+        - |
+          mkdir -p ~/.aws
+          # Write the AWS credentials to ~/.aws/credentials
+          /gojq -r '
+          . |
+          "[default]\n" +
+          "aws_access_key_id = " + .spec.secretS3.accessKeyID + "\n" +
+          "aws_secret_access_key = " + .spec.secretS3.accessSecretKey + "\n"
+          ' /data/cosi/BucketInfo > ~/.aws/credentials
+          
+          # Write the AWS config to ~/.aws/config
+          /gojq -r '
+          . |
+          "[default]\n" +
+          "endpoint_url = " + .spec.secretS3.endpoint + "\n" +
+          "region = " + .spec.secretS3.region + "\n"
+          ' /data/cosi/BucketInfo > ~/.aws/config
+      volumeMounts:
+        - name: cosi-secret
+          mountPath: /data/cosi
+        - name: aws-credentials
+          mountPath: /root/.aws/
+    - name: write-test-file
+      image: ghcr.io/itchyny/gojq:0.12.17
+      command:
+        - "sh"
+        - "-o"
+        - "xtrace" # Verbose output
+        - "-o"
+        - "errexit" # Exit on any error, except in a pipeline
+        - "-c"
+        - |
+          # Create a test file with the bucket name written to it
+          touch "/tmp/test-directory/file.txt"
+          /gojq -r .spec.bucketName /data/cosi/BucketInfo > "/tmp/test-directory/file.txt"
+      volumeMounts:
+        - name: cosi-secret
+          mountPath: /data/cosi
+        - name: test-directory
+          mountPath: /tmp/test-directory
   containers:
     - name: awscli
-      # TODO: Replace the image with an official one once Amazon publishes theirs
-      image: pknutanix/aws-cli:1.16.220
-      stdin: true
-      tty: true
+      image: amazon/aws-cli:2.22.21
+      command:
+        - "sh"
+        - "-o"
+        - "xtrace" # Verbose output
+        - "-o"
+        - "errexit" # Exit on any error, except in a pipeline
+        - "-c"
+        - |
+          # List all buckets
+          aws s3 ls
+         
+          # Copy a file to the bucket
+          readonly BUCKET_NAME=$(cat /tmp/test-directory/file.txt)
+          readonly FILE_NAME="$(date +%Y%m%d_%H%M%S).txt"
+          aws s3 cp /tmp/test-directory/file.txt s3://$BUCKET_NAME/$FILE_NAME
+
+          # Copy the file back from S3 to the terminal
+          aws s3 cp s3://$BUCKET_NAME/$FILE_NAME -
       volumeMounts:
-        - name: cosi-secrets
-          mountPath: /data/cosi
+        - name: aws-credentials
+          mountPath: /root/.aws/
+        - name: test-directory
+          mountPath: /tmp/test-directory
   volumes:
-  - name: cosi-secrets
+  - name: cosi-secret
     secret:
       secretName: bucketcreds
+  - name: aws-credentials
+    emptyDir: {}
+  - name: test-directory
+    emptyDir: {}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
I was testing out the examples and noticed that the awscli Pod was not working.

This PR switches to use `amazon/aws-cli` image and updated the command script to list and copy a test file.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

Followed the Quickstart from the README
```
$ kubectl logs awscli
Defaulted container "awscli" out of: awscli, write-aws-credentials (init), write-test-file (init)
+ aws s3 ls
2024-12-20 19:38:40 sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
++ cat /tmp/test-directory/file.txt
+ readonly BUCKET_NAME=sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
+ BUCKET_NAME=sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
++ date +%Y%m%d_%H%M%S
+ readonly FILE_NAME=20241220_213034.txt
+ FILE_NAME=20241220_213034.txt
+ aws s3 cp /tmp/test-directory/file.txt s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt
upload: ../tmp/test-directory/file.txt to s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt
+ aws s3 cp s3://sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102/20241220_213034.txt -
sample-bucketclassc949a8c0-4c73-46ea-ace8-20071bff8102
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```