### PR TITLE
charts: allow skipping the COSI central controller

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -39,33 +39,34 @@ To know more about the various flag options used with upgrade command check out 
 
 The following table lists the configurable parameters of the cosi-driver-nutanix chart and their default values.
 
-| Parameter                                          | Description                                                        | Default                                                                      |
-|----------------------------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------|
-| `nameOverride`                                     | To override the name of the cosi-driver chart                      | `""`                                                                         |
-| `fullnameOverride`                                 | To override the full name of the cosi-driver chart                 | `""`                                                                         |
-| `image.registry`                                   | Image registry for cosi-driver-nutanix sidecar                     | `ghcr.io/`                                                                   |
-| `image.repository`                                 | Image repository for cosi-driver-nutanix sidecar                   | `nutanix-cloud-native/cosi-driver-nutanix`                                   |
-| `image.tag`                                        | Image tag for cosi-driver-nutanix sidecar                          | `""`                                                                         |
-| `image.pullPolicy`                                 | Image registry for cosi-driver-nutanix sidecar                     | `IfNotPresent`                                                               |
-| `secret.enabled`                                   | Enables K8s secret deployment for Nutanix Object Store             | `true`                                                                       |
-| `secret.endpoint`                                  | Nutanix Object Store instance endpoint                             | `""`                                                                         |
-| `secret.access_key`                                | Admin IAM Access key to be used for Nutanix Objects                | `""`                                                                         |
-| `secret.secret_key`                                | Admin IAM Secret key to be used for Nutanix Objects                | `""`                                                                         |
-| `secret.pc_ip`                                     | PC ip                 | `""`                                       |
-| `secret.pc_port`                                   | PC port               | `""`                                       |
-| `secret.pc_username`                               | PC username           | `""`                                       |
-| `secret.pc_password`                               | PC password           | `""`                                       |
-| `secret.account_name`                              | Account Name is a displayName identifier Prefix for Nutanix        | `"ntnx-cosi-iam-user"`                                                       |
-| `cosiController.logLevel`                          | Verbosity of logs for COSI central controller deployment           | `5`                                                                          |
-| `cosiController.image.registery`                   | Image registry for COSI central controller deployment              | `gcr.io/`                                                                    |
-| `cosiController.image.repository`                  | Image repository for COSI central controller deployment            | `k8s-staging-sig-storage/objectstorage-controller`                           |
-| `cosiController.image.tag`                         | Image tag for COSI central controller deployment                   | `v20221027-v0.1.1-8-g300019f`                                                |
-| `cosiController.image.pullPolicy`                  | Image pull policy for COSI central controller deployment           | `Always`                                                                     |
-| `objectstorageProvisionerSidecar.logLevel`         | Verbosity of logs for COSI sidecar                                 | `5`                                                                          |
-| `objectstorageProvisionerSidecar.image.registery`  | Image registry for COSI sidecar                                    | `gcr.io/`                                                                    |
-| `objectstorageProvisionerSidecar.image.repository` | Image repository for COSI sidecar                                  | `k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar@sha256` |
-| `objectstorageProvisionerSidecar.image.tag`        | Image tag for COSI sidecar                                         | `589c0ad4ef5d0855fe487440e634d01315bc3d883f91c44cb72577ea6e12c890`           |
-| `objectstorageProvisionerSidecar.image.pullPolicy` | Image pull policy for COSI sidecar                                 | `Always`                                                                     |
+| Parameter                                          | Description                                                                | Default                                                                      |
+|----------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| `nameOverride`                                     | To override the name of the cosi-driver chart                              | `""`                                                                         |
+| `fullnameOverride`                                 | To override the full name of the cosi-driver chart                         | `""`                                                                         |
+| `image.registry`                                   | Image registry for cosi-driver-nutanix sidecar                             | `ghcr.io/`                                                                   |
+| `image.repository`                                 | Image repository for cosi-driver-nutanix sidecar                           | `nutanix-cloud-native/cosi-driver-nutanix`                                   |
+| `image.tag`                                        | Image tag for cosi-driver-nutanix sidecar                                  | `""`                                                                         |
+| `image.pullPolicy`                                 | Image registry for cosi-driver-nutanix sidecar                             | `IfNotPresent`                                                               |
+| `secret.enabled`                                   | Enables K8s secret deployment for Nutanix Object Store                     | `true`                                                                       |
+| `secret.endpoint`                                  | Nutanix Object Store instance endpoint                                     | `""`                                                                         |
+| `secret.access_key`                                | Admin IAM Access key to be used for Nutanix Objects                        | `""`                                                                         |
+| `secret.secret_key`                                | Admin IAM Secret key to be used for Nutanix Objects                        | `""`                                                                         |
+| `secret.pc_ip`                                     | PC ip                                                                      | `""`                                                                         |
+| `secret.pc_port`                                   | PC port                                                                    | `""`                                                                         |
+| `secret.pc_username`                               | PC username                                                                | `""`                                                                         |
+| `secret.pc_password`                               | PC password                                                                | `""`                                                                         |
+| `secret.account_name`                              | Account Name is a displayName identifier Prefix for Nutanix                | `"ntnx-cosi-iam-user"`                                                       |
+| `cosiController.create`                            | Whether to create the COSI central controller deployment and its resources | `true`                                                                       |
+| `cosiController.logLevel`                          | Verbosity of logs for COSI central controller deployment                   | `5`                                                                          |
+| `cosiController.image.registery`                   | Image registry for COSI central controller deployment                      | `gcr.io/`                                                                    |
+| `cosiController.image.repository`                  | Image repository for COSI central controller deployment                    | `k8s-staging-sig-storage/objectstorage-controller`                           |
+| `cosiController.image.tag`                         | Image tag for COSI central controller deployment                           | `v20221027-v0.1.1-8-g300019f`                                                |
+| `cosiController.image.pullPolicy`                  | Image pull policy for COSI central controller deployment                   | `Always`                                                                     |
+| `objectstorageProvisionerSidecar.logLevel`         | Verbosity of logs for COSI sidecar                                         | `5`                                                                          |
+| `objectstorageProvisionerSidecar.image.registery`  | Image registry for COSI sidecar                                            | `gcr.io/`                                                                    |
+| `objectstorageProvisionerSidecar.image.repository` | Image repository for COSI sidecar                                          | `k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar@sha256` |
+| `objectstorageProvisionerSidecar.image.tag`        | Image tag for COSI sidecar                                                 | `589c0ad4ef5d0855fe487440e634d01315bc3d883f91c44cb72577ea6e12c890`           |
+| `objectstorageProvisionerSidecar.image.pullPolicy` | Image pull policy for COSI sidecar                                         | `Always`                                                                     |
 
 ### Configuration examples:
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the cosi-driver-nutanix
 | `secret.pc_username`                               | PC username                                                                | `""`                                                                         |
 | `secret.pc_password`                               | PC password                                                                | `""`                                                                         |
 | `secret.account_name`                              | Account Name is a displayName identifier Prefix for Nutanix                | `"ntnx-cosi-iam-user"`                                                       |
-| `cosiController.create`                            | Whether to create the COSI central controller deployment and its resources | `true`                                                                       |
+| `cosiController.enabled`                           | Whether to create the COSI central controller deployment and its resources | `true`                                                                       |
 | `cosiController.logLevel`                          | Verbosity of logs for COSI central controller deployment                   | `5`                                                                          |
 | `cosiController.image.registery`                   | Image registry for COSI central controller deployment                      | `gcr.io/`                                                                    |
 | `cosiController.image.repository`                  | Image repository for COSI central controller deployment                    | `k8s-staging-sig-storage/objectstorage-controller`                           |

--- a/charts/templates/cosi-controller.yaml
+++ b/charts/templates/cosi-controller.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cosiController.create }}
+{{- if .Values.cosiController.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/templates/cosi-controller.yaml
+++ b/charts/templates/cosi-controller.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cosiController.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -101,3 +102,4 @@ spec:
         imagePullPolicy: {{ .Values.cosiController.image.pullPolicy }}
         name: objectstorage-controller
       serviceAccountName: objectstorage-controller-sa
+{{- end}}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -32,6 +32,7 @@ secret:
 
 # COSI central controller specifications.
 cosiController:
+  create: true
   logLevel: 5
   image:
     registry: gcr.io

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -32,7 +32,7 @@ secret:
 
 # COSI central controller specifications.
 cosiController:
-  create: true
+  enabled: true
   logLevel: 5
   image:
     registry: gcr.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Making the Chart more flexible to enable deploying the COSI central controller separately.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

With the new value:
```
$ helm install cosi-driver -n cosi-driver-nutanix --create-namespace --set=secret.enabled=false --set=cosiController.enabled=false --skip-crds charts
NAME: cosi-driver
LAST DEPLOYED: Mon Dec 23 10:05:06 2024
NAMESPACE: cosi-driver-nutanix
STATUS: deployed
REVISION: 1
TEST SUITE: None

$ kubectl get deploy -A | grep objectstorage-controller | wc -l
0
```

With default:
```
$ helm install cosi-driver -n cosi-driver-nutanix --create-namespace --set=secret.enabled=false charts                                                                                          
NAME: cosi-driver
LAST DEPLOYED: Fri Dec 20 14:28:17 2024
NAMESPACE: cosi-driver-nutanix
STATUS: deployed
REVISION: 1
TEST SUITE: None
$ kubectl get deploy -A | grep objectstorage-controller | wc -l
1
```


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```