### PR TITLE
fix: Add missing bucketclasses to rbac resource list

### DIFF
--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -7,15 +7,47 @@ metadata:
 {{ include "cosi-driver-nutanix.resource.labels" . | indent 4 }}
   name: objectstorage-provisioner-role
 rules:
-  - apiGroups: ["objectstorage.k8s.io"]
-    resources: ["buckets", "bucketaccesses","buckets/status", "bucketaccesses/status", "bucketaccessclasses", "bucketaccessclasses/status", "bucketclaims", "bucketclaims/status"]
-    verbs: ["get", "list", "watch", "update", "create", "delete"]
-  - apiGroups: ["coordination.k8s.io"]
-    resources: ["leases"]
-    verbs: ["get", "watch", "list", "delete", "update", "create"]
-  - apiGroups: [""]
-    resources: ["secrets", "events"]
-    verbs: ["get", "delete", "update", "create"]
+  - apiGroups:
+      - objectstorage.k8s.io
+    resources:
+      - bucketaccessclasses
+      - bucketaccessclasses/status
+      - bucketaccesses
+      - bucketaccesses/status
+      - bucketclaims
+      - bucketclaims/status
+      - bucketclasses
+      - bucketclasses/status
+      - buckets
+      - buckets/status
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - list
+      - delete
+      - update
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - events
+    verbs:
+      - get
+      - delete
+      - update
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This PR fixes the RBAC issue in the `object storage-provisioner-role` `ClusterRole`. 
The issue seems only reproducible if the `BucketClaim` is pointing to a pre-existing bucket and does not affect the case when buckets are provisioned dynamically.
Additionaly, the PR refactors introduce some refactoring to improve readaility.
```
objectstorage-provisioner-sidecar I0121 20:59:33.120909       1 bucket_controller.go:69] "Add Bucket" name="nkp-insights-bucket"
objectstorage-provisioner-sidecar E0121 20:59:33.122439       1 bucket_controller.go:104] "Error fetching bucketClass" err="bucketclasses.objectstorage.k8s.io \"ntnx-bucketclass\" is forbidden: User \"system:servi
ceaccount:cosi-driver-nutanix:objectstorage-provisioner-sa\" cannot get resource \"bucketclasses\" in API group \"objectstorage.k8s.io\" at the cluster scope" bucketClass="ntnx-bucketclass" bucket="nkp-insights-bu
cket"

```

**How Has This Been Tested?**:
1. Create a bucket in the Nutanix Object store. 
2. Install the chart: 
```
helm install cosi-driver -n cosi-driver-nutanix --create-namespace --set=secret.enabled=false --set=cosiController.enabled=false --skip-crds charts
```
Create `BucketClaim` referencing the bucket in `existingBucketName`:
```
cat <<EOF | kubectl apply -f -
kind: BucketClass
apiVersion: objectstorage.k8s.io/v1alpha1
metadata:
  name: ntnx-bucketclass
driverName: ntnx.objectstorage.k8s.io
deletionPolicy: Delete
---
kind: BucketAccessClass
apiVersion: objectstorage.k8s.io/v1alpha1
metadata:
  name: ntnx-bucketaccessclass
driverName: ntnx.objectstorage.k8s.io
authenticationType: KEY
---
apiVersion: objectstorage.k8s.io/v1alpha1
kind: BucketClaim
metadata:
  name: nkp-insights-objectstore-eb
spec:
  bucketClassName: ntnx-bucketclass
  existingBucketName: nkp-insights
  protocols:
  - s3
---
EOF
```
Verify the `Bucket` CR is created:
```
apiVersion: objectstorage.k8s.io/v1alpha1
kind: Bucket
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"objectstorage.k8s.io/v1alpha1","kind":"Bucket","metadata":{"annotations":{},"name":"nkp-insights-bucket"},"spec":{"bucketClaim":{"name":"nkp-insights-objectstore"},"bucketClassName":"ntnx-buck
etclass","driverName":"ntnx.objectstorage.k8s.io","existingBucketID":"nkp-insights","protocols":["s3"]}}
  creationTimestamp: "2025-01-21T14:39:27Z"
  finalizers:
  - cosi.objectstorage.k8s.io/bucket-protection
  generation: 1
  name: nkp-insights-bucket
  resourceVersion: "2305263"
  uid: 9aeab36b-f752-469c-a3f4-9ffb3fdc0712
spec:
  bucketClaim:
    name: nkp-insights-objectstore
  bucketClassName: ntnx-bucketclass
  deletionPolicy: Retain
  driverName: ntnx.objectstorage.k8s.io
  existingBucketID: nkp-insights
  protocols:
  - s3
status:
  bucketID: nkp-insights
  bucketReady: true
```



**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```