### PR TITLE
feat: Allow PutLifecycleConfiguration action by default

### DIFF
--- a/pkg/util/s3client/policy.go
+++ b/pkg/util/s3client/policy.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 You may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -83,6 +83,7 @@ var AllowedActions = []action{
 	ListBucket,
 	ListMultipartUploadParts,
 	PutObject,
+	PutLifecycleConfiguration,
 }
 
 type effect string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Adds `PutBucketLifecycleConfiguration` to the default allowed actions list. This will allow users with `BucketAccess` to set or update the lifecycle configuration of an S3 bucket, such as object expiration or TTL. 

**How Has This Been Tested?**:
Tested by using AWS Go SDK and the following code:
```
lifecycleConfiguration := &s3.BucketLifecycleConfiguration{
		Rules: []*s3.LifecycleRule{
			{
				Expiration: &s3.LifecycleExpiration{
					Days: aws.Int64(days),
				},
				ID:     aws.String("TTL"),
				Prefix: aws.String("prefix"),
				Status: aws.String("Enabled"),
			},
		},
	}

	_, err := o.s3Session.PutBucketLifecycleConfiguration(&s3.PutBucketLifecycleConfigurationInput{
		Bucket:                 aws.String(bucket),
		LifecycleConfiguration: lifecycleConfiguration,
	})
```


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```