### PR TITLE
Added TLS Support to ObjectStore endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ CMDS=cosi-driver-nutanix
 REGISTRY_NAME=ghcr.io/nutanix-cloud-native/cosi-driver-nutanix
 IMAGE_TAG=latest
 
+LOCAL_REGISTRY_NAME=cosi-driver-nutanix
+LOCAL_IMAGE_TAG=debug
+
 all: build
 
 .PHONY: build-% build container-% container clean
@@ -50,3 +53,8 @@ docker-push:
 
 clean:
 	-rm -rf bin
+
+# Creates an image of the driver in local environment
+local-%: build-%
+	docker build -t $(LOCAL_REGISTRY_NAME):$(LOCAL_IMAGE_TAG) -f package/docker/Dockerfile --label revision=$(REV) .
+local: $(CMDS:%=local-%)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ $ cd cosi-driver-nutanix
 - `SECRET_KEY` : Nutanix Object Store Secret Key
 - `PC_SECRET` : Prism Central Credentials in the form 'prism-ip:prism-port:username:password'
 - `ACCOUNT_NAME` (Optional) : DisplayName identifier prefix for Nutanix Object Store (Default_Prefix: ntnx-cosi-iam-user)
+- `CA_CERT` (Optional) : CA Certificate to be used by the S3 Client (Default: "")
 
 **Pre-requisites:**
 Already deployed Nutanix object-store
@@ -165,6 +166,9 @@ Update the `objectstorage-provisioner` secret that is used by the running provis
   # PC Credentials in format <prism-ip>:<prism-port>:<user>:<password>. 
   # eg. "<ip>:<port>:user:password"
   PC_SECRET: ""
+  # CA Cert for Object Store endpoint TLS in b64 encoded format
+  # empty if no certs should be used.
+  CA_CERT: ""
 ```
 
 Then restart the provisioner pod so that the new secret changes getting mounted on the new pod and will thereon be used.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cosi-driver-nutanix
 description: A Helm chart to deploy Nutanix COSI driver
 type: application
-version: 0.0.4
+version: 0.2.1
 
-appVersion: "v0.0.4"
+appVersion: "v0.2.1"
 
 icon: https://www.nutanix.com/content/dam/nutanix/global/icons/products/svg/Nutanix-Objects-40.svg
 annotations:

--- a/charts/README.md
+++ b/charts/README.md
@@ -56,6 +56,7 @@ The following table lists the configurable parameters of the cosi-driver-nutanix
 | `secret.pc_username`                               | PC username                                                                | `""`                                                                         |
 | `secret.pc_password`                               | PC password                                                                | `""`                                                                         |
 | `secret.account_name`                              | Account Name is a displayName identifier Prefix for Nutanix                | `"ntnx-cosi-iam-user"`                                                       |
+| `certs.ca`                         			     | Certificate to be used by the S3 Client									  | `""`                              					                         |
 | `cosiController.enabled`                           | Whether to create the COSI central controller deployment and its resources | `true`                                                                       |
 | `cosiController.logLevel`                          | Verbosity of logs for COSI central controller deployment                   | `5`                                                                          |
 | `cosiController.image.registery`                   | Image registry for COSI central controller deployment                      | `gcr.io/`                                                                    |

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -14,5 +14,6 @@ stringData:
   ENDPOINT: {{ required "endpoint is required." .Values.secret.endpoint | quote }}
   PC_SECRET: "{{ required "pc_ip is required." .Values.secret.pc_ip }}:{{ required "pc_port is required." .Values.secret.pc_port }}:{{ required "pc_username is required." .Values.secret.pc_username }}:{{ required "pc_password is required." .Values.secret.pc_password }}"
   SECRET_KEY: {{ required "secret_key is required." .Values.secret.secret_key | quote }}
+  CA_CERT: {{ .Values.certs.ca | b64enc }}
 type: Opaque
 {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -30,6 +30,32 @@ secret:
   # (Default_Prefix: ntnx-cosi-iam-user)
   account_name: "ntnx-cosi-iam-user"
 
+# Certificate to be used by the S3 Client. Example,
+# certs:
+#   ca: |
+#     -----BEGIN CERTIFICATE-----
+#     MIIDVDCCAjygAwIBAgIRALLmZX4DorTkHZzNVhA+RYUwDQYJKoZIhvcNAQELBQAw
+#     FzEVMBMGA1UEChMMTnV0YW5peCBJbmMuMCAXDTI1MDEyNzA4MDU0NVoYDzIyMDQw
+#     NzAzMDgwNTQ1WjAXMRUwEwYDVQQKEwxOdXRhbml4IEluYy4wggEiMA0GCSqGSIb3
+#     DQEBAQUAA4IBDwAwggEKAoIBAQDXvGBSfAByt1VCvAuaDThq7H+JlK8He8zcjqD7
+#     DGe6Dc1jq9n7+eN6X+cTT85dKPhajjPp9Nc4g1HT0jfWHD4QHhgkS12Ny0Wrmqqr
+#     qx8Fcuzhaz89BFyaI3tOCBx75yZe9zaNSOBoKJqreu2mAjfI8LM7jFl/cON68Kd9
+#     /b6g89+2FME0gFq2p3mabGXGVerFAK0g7TuffhWKyKL/B9equZ2M7CmhAO7wa0ko
+#     CnQJY3XvNk4OUeb7NXBdpswpWD789rXSsSMbxaS9ZmDrqvB7A1IlWjwEUVzxYnPw
+#     21miqfZ5qb2p3gZtSTbDOqmg0l9yfvwIroaGKMLrRCK0Q+IjAgMBAAGjgZgwgZUw
+#     DgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFPE9h85q
+#     h53rKbrBRd+VnUGuAxpKMFMGA1UdEQRMMEqCInJpbXVydS5wcmlzbS1jZW50cmFs
+#     LmNsdXN0ZXIubG9jYWyCJCoucmltdXJ1LnByaXNtLWNlbnRyYWwuY2x1c3Rlci5s
+#     b2NhbDANBgkqhkiG9w0BAQsFAAOCAQEAd3wN98xaTJqBGE2j0qoSQhqMNb5NmBDa
+#     Cp/Pt0mwlAJmv2petz3ON5edt3/yC81vEvWfT+4GpM/6jAHcY9rZ+XQA+ZkSnjsG
+#     itALgSLq77vDYRTHAXfsWPH2DY140IS6OqqTtLPLukHzux5uR2LH1uggU5sARs5l
+#     EBi1znwsnSxrKfqPOurt4oSgW7FougqiaOiK+Vkm+1FtybVlMXL1w5TkePFK/x7B
+#     OkiKpPoALmPy1Y2BxvbpxQYLjZEFMKwIo7G20pl9opFntCBs6GcY7QNesVYKawV1
+#     zQEsbJYBuhj1XgjzRx+6al2Fjf2NFN3I2aCKQZ9oMFsg0R/M0biBjA==
+#     -----END CERTIFICATE-----
+certs:
+  ca: ""
+
 # COSI central controller specifications.
 cosiController:
   enabled: true

--- a/cmd/cosi-driver-nutanix/cmd.go
+++ b/cmd/cosi-driver-nutanix/cmd.go
@@ -43,6 +43,7 @@ var (
 	PCPassword    = ""
 	PCSecret      = ""
 	AccountName   = ""
+	CACert		  = ""
 )
 
 var cmd = &cobra.Command{
@@ -105,6 +106,12 @@ func init() {
 		AccountName,
 		"User IAM Account Name is an identifier for Nutanix Objects")
 
+	stringFlag(&CACert,
+		"ca_cert",
+		"c",
+		CACert,
+		"CA Certificate")
+
 	viper.BindPFlags(cmd.PersistentFlags())
 	cmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
 		if viper.IsSet(f.Name) && viper.GetString(f.Name) != "" {
@@ -115,7 +122,7 @@ func init() {
 
 func run(ctx context.Context, args []string) error {
 	PCEndpoint, PCUsername, PCPassword, err := ntnxIam.GetCredsFromPCSecret(PCSecret)
-	klog.InfoS(PCEndpoint, PCUsername, PCPassword, err)
+	klog.InfoS(PCEndpoint, PCUsername, PCPassword, CACert, err)
 	if err != nil {
 		return err
 	}
@@ -128,7 +135,8 @@ func run(ctx context.Context, args []string) error {
 		PCEndpoint,
 		PCUsername,
 		PCPassword,
-		AccountName)
+		AccountName,
+		CACert)
 	if err != nil {
 		return err
 	}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -25,9 +25,9 @@ import (
 )
 
 func NewDriver(ctx context.Context, provisioner, ntnxEndpoint, accessKey, secretKey,
-	pcEndpoint, pcUsername, pcPassword, accountName string) (*IdentityServer, *ProvisionerServer, error) {
+	pcEndpoint, pcUsername, pcPassword, accountName, caCertB64 string) (*IdentityServer, *ProvisionerServer, error) {
 
-	s3Client, err := s3client.NewS3Agent(accessKey, secretKey, ntnxEndpoint, true)
+	s3Client, err := s3client.NewS3Agent(accessKey, secretKey, ntnxEndpoint, caCertB64, true)
 	if err != nil {
 		klog.Fatalln(err)
 	}

--- a/project/resources/cosi-driver-ntnx.properties
+++ b/project/resources/cosi-driver-ntnx.properties
@@ -1,4 +1,4 @@
 OBJECTSTORAGE_PROVISIONER_IMAGE_ORG=quay.io/containerobjectstorage
 OBJECTSTORAGE_PROVISIONER_IMAGE_VERSION=canary
-NTNX_DRIVER_IMAGE_ORG=nutanix-cloud-native
+NTNX_DRIVER_IMAGE_ORG=ghcr.io/nutanix-cloud-native
 NTNX_DRIVER_IMAGE_VERSION=latest

--- a/project/resources/deployment.yaml
+++ b/project/resources/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - mountPath: /var/lib/cosi
           name: socket
       - name: objectstorage-provisioner-sidecar
-        image: k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar:v20221117-v0.1.0-22-g0e67387
+        image: gcr.io/k8s-staging-sig-storage/objectstorage-sidecar/objectstorage-sidecar:v20221117-v0.1.0-22-g0e67387
         imagePullPolicy: Always
         args:
         - "--v=5"

--- a/project/resources/secret.yaml
+++ b/project/resources/secret.yaml
@@ -18,6 +18,9 @@ stringData:
   # PC Credentials in format <prism-ip>:<prism-port>:<user>:<password>. 
   # eg. "10.51.142.125:9440:user:password"
   PC_SECRET: "<PRISM-IP>:<PRISM-PORT>:<USER>:<PASSWORD>"
+  # CA Cert for Object Store endpoint TLS in b64 encoded format
+  # empty if no certs should be used.
+  CA_CERT: ""
   # Account Name is a displayName identifier Prefix for Nutanix 
   # Objects to ensure that multiple requests for the same account
   # result in only one access token being created


### PR DESCRIPTION
**Summary**
This PR adds TLS support for S3 connections in the Nutanix COSI driver. Users can now configure HTTPS connections and provide CA certificates for enhanced security.

**Changes**

- Enabled HTTPS support for S3 connections.
- Added support for CA certificates.
- Users can:
  - Configure certificates via `/charts/values.yaml` (Helm deployment).
  - Manually provide a base64-encoded certificate in `/project/resources/secret.yaml` (manual deployment).
- Updated documentation and example configurations to reflect these changes.

**Testing**

- Verified S3 connections over HTTPS.
- Tested certificate injection via both deployment methods.

**Notes**

- If no certificate is provided and an HTTPS endpoint is used, an `insecure` connection will be made.