### PR TITLE
fix: removes sensitive info of PC username and password from logs

### DIFF
--- a/cmd/cosi-driver-nutanix/cmd.go
+++ b/cmd/cosi-driver-nutanix/cmd.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"strings"
 
 	ntnxIam "github.com/nutanix-core/k8s-ntnx-object-cosi/pkg/admin"
@@ -50,8 +51,8 @@ var cmd = &cobra.Command{
 	Short:         "Kubernetes COSI driver for Nutanix Object Store",
 	SilenceErrors: true,
 	SilenceUsage:  true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return run(cmd.Context(), args)
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return run(cmd.Context())
 	},
 	DisableFlagsInUseLine: true,
 }
@@ -113,10 +114,11 @@ func init() {
 	})
 }
 
-func run(ctx context.Context, args []string) error {
+func run(ctx context.Context) error {
 	PCEndpoint, PCUsername, PCPassword, err := ntnxIam.GetCredsFromPCSecret(PCSecret)
-	klog.InfoS(PCEndpoint, PCUsername, PCPassword, err)
 	if err != nil {
+		errMsg := fmt.Errorf("failed to extract PC credential information from secret %q: %w", PCSecret, err)
+		klog.Error(errMsg)
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->


**What this PR does / why we need it**:
PR fixes issue where sensitive info of PC username and password was getting printed in plain text in logs.. this could avoid potential security threat for PC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 
https://jira.nutanix.com/browse/NCN-105878

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_

```
./bin/cosi-driver-nutanix --pc_secret "dummy-secret"
E0225 16:51:01.459975   89508 cmd.go:121] failed to extract PC credential information from secret "dummy-secret": missing information in secret value '<prism-ip>:<prism-port>:<pc_user>:<pc_password>'
E0225 16:51:01.460318   89508 main.go:46] "Exiting on error" err="missing information in secret value '<prism-ip>:<prism-port>:<pc_user>:<pc_password>'"
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```