### PR TITLE
fix: corrects description of flag pc_secret and removes its value from logs

### DIFF
--- a/cmd/cosi-driver-nutanix/cmd.go
+++ b/cmd/cosi-driver-nutanix/cmd.go
@@ -98,7 +98,7 @@ func init() {
 		"pc_secret",
 		"k",
 		PCSecret,
-		"Base64 encoded format of <prism-ip>:<prism-port>:<pc_user>:<pc_password>")
+		"Prism Central Credentials in the format <prism-ip>:<prism-port>:<pc_user>:<pc_password>")
 
 	stringFlag(&AccountName,
 		"account_name",
@@ -117,7 +117,7 @@ func init() {
 func run(ctx context.Context) error {
 	PCEndpoint, PCUsername, PCPassword, err := ntnxIam.GetCredsFromPCSecret(PCSecret)
 	if err != nil {
-		errMsg := fmt.Errorf("failed to extract PC credential information from secret %q: %w", PCSecret, err)
+		errMsg := fmt.Errorf("failed to extract PC credential information from secret: %w", err)
 		klog.Error(errMsg)
 		return err
 	}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
PR corrects description of flag pc_secret as it accepts input in plain text than base64 encoded and removes its value from logs

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://jira.nutanix.com/browse/NCN-105878

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


```
./bin/cosi-driver-nutanix -h
Kubernetes COSI driver for Nutanix Object Store

Usage:
  cosi-driver-nutanix

Flags:
  -a, --access_key string                Admin IAM Access key to be used for Nutanix Objects
  -u, --account_name string              User IAM Account Name is an identifier for Nutanix Objects
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
  -d, --driver_address string            Path to unix domain socket where driver should listen (default "unix:///var/lib/cosi/cosi.sock")
  -e, --endpoint string                  Nutanix Object Store instance endpoint
  -h, --help                             help for cosi-driver-nutanix
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
  -k, --pc_secret string                 Prism Central Credentials in the format <prism-ip>:<prism-port>:<pc_user>:<pc_password>
  -s, --secret_key string                Admin IAM Secret key to be used for Nutanix Objects
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
```

```
./bin/cosi-driver-nutanix --pc_secret "incorrect-secret"   
E0225 23:18:13.907929   98210 cmd.go:121] failed to extract PC credential information from secret: missing information in secret value '<prism-ip>:<prism-port>:<pc_user>:<pc_password>'
E0225 23:18:13.908236   98210 main.go:46] "Exiting on error" err="missing information in secret value '<prism-ip>:<prism-port>:<pc_user>:<pc_password>'"
```

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```