### PR TITLE
Added support for TLS Validation when CA Certs are not provided explicitly

### DIFF
--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: cosi-driver-nutanix
 description: A Helm chart to deploy Nutanix COSI driver
 type: application
-version: 0.5.0
+version: 0.6.0
 
-appVersion: "v0.5.0"
+appVersion: "v0.6.0"
 
 icon: https://www.nutanix.com/content/dam/nutanix/global/icons/products/svg/Nutanix-Objects-40.svg
 annotations:

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -16,11 +16,9 @@ stringData:
   SECRET_KEY: {{ required "secret_key is required." .Values.secret.secret_key | quote }}
   S3_INSECURE: {{ .Values.tls.s3.insecure | default "false" | quote }}
   PC_INSECURE: {{ .Values.tls.pc.insecure | default "false" | quote }}
-  {{- if and (not .Values.tls.caSecretName ) (eq .Values.tls.s3.insecure false) }}
-  S3_CA_CERT: {{ required "CA Certificate required if insecure set to false" .Values.tls.s3.rootCAs }}
-  {{- end }}
-  {{- if and (not .Values.tls.caSecretName ) (eq .Values.tls.pc.insecure false) }}
-  PC_CA_CERT: {{ required "CA Certificate required if insecure set to false" .Values.tls.pc.rootCAs }}
+  {{- if not .Values.tls.caSecretName }}
+  S3_CA_CERT: {{ .Values.tls.s3.rootCAs | default "" }}
+  PC_CA_CERT: {{ .Values.tls.pc.rootCAs | default "" }}
   {{- end }}
 type: Opaque
 {{- end }}

--- a/pkg/util/transport/transport.go
+++ b/pkg/util/transport/transport.go
@@ -28,43 +28,49 @@ func BuildTransportTLS(tlsConfig TlsConfig) (*http.Transport, error) {
 		}
 
 		klog.InfoS("insecure connection made.", "insecure", tlsConfig.Insecure, "endpoint", tlsConfig.Endpoint)
-	} else {
-		if tlsConfig.CACert == "" {
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: false,
-				},
-			}
-		} else {
-			var rootCAs []byte
-			if strings.Contains(tlsConfig.CACert, "-----BEGIN CERTIFICATE-----") && strings.Contains(tlsConfig.CACert, "-----END CERTIFICATE-----") {
-				rootCAs = []byte(tlsConfig.CACert)
-			} else {
-				// Decode base64 CA cert
-				_rootCAs, err := base64.StdEncoding.DecodeString(tlsConfig.CACert)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode CA cert: %v", err)
-				}
 
-				rootCAs = _rootCAs
-			}
+		return transport, nil
+	}
 
-			// Create cert pool and add our CA
-			caCertPool := x509.NewCertPool()
-			if !caCertPool.AppendCertsFromPEM(rootCAs) {
-				return nil, fmt.Errorf("failed to append CA cert: %s", tlsConfig.CACert)
-			}
-
-			transport = &http.Transport{
-				TLSClientConfig: &tls.Config{
-					RootCAs:            caCertPool,
-					InsecureSkipVerify: false,
-				},
-			}
+	if tlsConfig.CACert == "" {
+		transport = &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: false,
+			},
 		}
 
-		klog.InfoS("secure connection made.", "insecure", tlsConfig.Insecure, "endpoint", tlsConfig.Endpoint)
+		klog.InfoS("secure connection made without CA certs.", "insecure", tlsConfig.Insecure, "endpoint", tlsConfig.Endpoint)
+
+		return transport, nil
 	}
+
+	var rootCAs []byte
+	if strings.Contains(tlsConfig.CACert, "-----BEGIN CERTIFICATE-----") && strings.Contains(tlsConfig.CACert, "-----END CERTIFICATE-----") {
+		rootCAs = []byte(tlsConfig.CACert)
+	} else {
+		// Decode base64 CA cert
+		_rootCAs, err := base64.StdEncoding.DecodeString(tlsConfig.CACert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode CA cert: %v", err)
+		}
+
+		rootCAs = _rootCAs
+	}
+
+	// Create cert pool and add our CA
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(rootCAs) {
+		return nil, fmt.Errorf("failed to append CA cert: %s", tlsConfig.CACert)
+	}
+
+	transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs:            caCertPool,
+			InsecureSkipVerify: false,
+		},
+	}
+
+	klog.InfoS("secure connection made with CA certs.", "insecure", tlsConfig.Insecure, "endpoint", tlsConfig.Endpoint)
 
 	return transport, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Now users can configure COSI with TLS Validation when CA Certs are not provided for when user has publicly trusted certs on the endpoint and wants TLS Validation.

**How Has This Been Tested?**:
Manual and Unit tests
